### PR TITLE
Ajuste na definição de branches no CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ "main", "master", "develop" ] # Defina os branches que devem ser protegidos
+    branches: [ "main", "master", "develop" ]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Removido espaço em branco na configuração dos branches protegidos no arquivo ci.yml. A funcionalidade permanece inalterada, mantendo os branches "main", "master" e "develop" para eventos de pull request.