### PR TITLE
Check database creation before seeding data

### DIFF
--- a/FCG.API/Program.cs
+++ b/FCG.API/Program.cs
@@ -92,10 +92,11 @@ if (app.Environment.IsDevelopment() || app.Environment.IsStaging() || app.Enviro
     {
         await using var scope = app.Services.CreateAsyncScope();
         await using var dbContext = scope.ServiceProvider.GetRequiredService<FCGDbContext>();
-        dbContext.Database.EnsureCreated();
-
-        await RoleAndAdminSeeding.SeedAsync(scope.ServiceProvider);
-        await GameSeeding.SeedAsync(dbContext);
+        if (dbContext.Database.EnsureCreated())
+        {
+            await RoleAndAdminSeeding.SeedAsync(scope.ServiceProvider);
+            await GameSeeding.SeedAsync(dbContext);
+        }
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
Modified the seeding logic to only execute if the database was newly created by checking the result of `dbContext.Database.EnsureCreated()`. This change prevents redundant operations and potential errors when the database already exists.